### PR TITLE
Move to require-dev for phpunit and phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
     ],
     "require": {
         "php": ">=8.1",
-        "pds/skeleton": "^1.0",
+        "pds/skeleton": "^1.0"
+    },
+    "require-dev": {
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.0"
     },


### PR DESCRIPTION
Not sure why you kept dev dependencies on require. Sending a PR if that was a typo.